### PR TITLE
fix: #1 file-transformer resolves path relative to rootDir of jest

### DIFF
--- a/tools/file-transformer-jest.js
+++ b/tools/file-transformer-jest.js
@@ -6,7 +6,9 @@ module.exports = {
   process(src, filename, config, options) {
     // Fake url-loader
     return `module.exports = ${JSON.stringify(
-      `data:asset/${path.extname(filename).replace('.', '')};base64,${Buffer.from(filename).toString('base64')}`,
+      `data:asset/${path.extname(filename).replace('.', '')};base64,${Buffer.from(
+        path.relative(config.rootDir, filename).replace(/(\\{1,2})/, '/'),
+      ).toString('base64')}`,
     )}`;
   },
 };


### PR DESCRIPTION
**Purpose**
Resolves issue with file-transformer in tests using absolute path resulting in different base64 encodings.
Closes: #1 

**Approach**
The file-transformer now resolves the path relative to the specified rootDir of jest.